### PR TITLE
fix(webpack-permissions.plugin): trying set permissions on failed compilation

### DIFF
--- a/webpack-permissions.plugin.js
+++ b/webpack-permissions.plugin.js
@@ -13,7 +13,7 @@ class WebpackPermissionsPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.done.tap('Webpack Permissions Plugin', (stats) => {
+    compiler.hooks.afterEmit.tap('Webpack Permissions Plugin', (stats) => {
       const permissions = this.options.permissions || '755';
       const directoryPath = this.options.directoryPath || 'bin';
       const permissionPath = path.join(compiler.outputPath, directoryPath);


### PR DESCRIPTION
CHANGELOG:
 - Fix issue when compilation has done with errors and assets does not emitted, but webpack permissions plugin trying set permissions