### PR TITLE
[FIX] Cannot read property 'isAxiosError' of undefined

### DIFF
--- a/helper/logger.ts
+++ b/helper/logger.ts
@@ -17,7 +17,7 @@ export function log(...args): undefined {
         /**
          * Axios error has complicated structure that doesn't allow debugging it easily
          */
-        if (arg.isAxiosError) {
+        if (arg?.isAxiosError) {
           return JSON.stringify(format(arg));
         }
         return JSON.stringify(arg);


### PR DESCRIPTION
**CHANGELOG**
- Fix error if undefined parameter is passed to the log function, then cannot read property 'isAxiosError' of undefined